### PR TITLE
Remove Registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,3 +232,15 @@ jobs:
         run: sudo apt-get install wine64 mingw-w64
       - name: Build and test
         run: env CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUNNER=wine64 cargo test --features hdf5-sys/static --target x86_64-pc-windows-gnu -- --skip test_compile_fail
+  addr_san:
+    name: Address sanitizer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with: {submodules: true}
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with: {toolchain: nightly, profile: minimal, override: true}
+      - name: Run test with sanitizer
+        run: env RUSTFLAGS="-Z sanitizer=address" cargo test --features hdf5-sys/static --target x86_64-unknown-linux-gnu --workspace --exclude hdf5-derive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,8 @@
 - Added support for creating external links on a `Group` with `link_external`.
 - Added `Location` methods: `get_info`, `get_info_by_name`, `loc_type`, and `open_by_token`.
 - Added `Group` methods: `iter_visit`, `iter_visit_default`, `get_all_of_type`, `datasets`, `groups`, and `named_datatypes`.
-  
+- Additional iterators for getting groups, datasets, and datatypes.
+
  ### Changed
 
 - Required Rust compiler version is now `1.51`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@
   but must read the entire attribute at once).
 - Added support in `hdf5-sys` for the new functions in `hdf5` `1.10.6` and `1.10.7`.
 - Added support for creating external links on a `Group` with `link_external`.
+- Added `Location` methods: `get_info`, `get_info_by_name`, `loc_type`, and `open_by_token`.
+- Added `Group` methods: `iter_visit`, `iter_visit_default`, `get_all_of_type`, `datasets`, `groups`, and `named_datatypes`.
   
  ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,10 @@
 - Errors are not expanded when encountered, but only when being used for printing or by
   the library user.
 
+### Fixed
+
+- A memory leak of handles has been identified and fixed.
+
 ## 0.7.1
 
 ### Added

--- a/hdf5-sys/src/h5.rs
+++ b/hdf5-sys/src/h5.rs
@@ -1,3 +1,4 @@
+//! General purpose library functions
 use std::mem;
 
 pub use self::H5_index_t::*;

--- a/hdf5-sys/src/h5a.rs
+++ b/hdf5-sys/src/h5a.rs
@@ -1,3 +1,4 @@
+//! Creating and manipulating HDF5 attributes
 use std::mem;
 
 use crate::internal_prelude::*;

--- a/hdf5-sys/src/h5ac.rs
+++ b/hdf5-sys/src/h5ac.rs
@@ -1,3 +1,4 @@
+//! Cache functions
 use std::mem;
 
 use crate::internal_prelude::*;

--- a/hdf5-sys/src/h5c.rs
+++ b/hdf5-sys/src/h5c.rs
@@ -1,3 +1,4 @@
+//! Cache functionality
 pub use self::H5C_cache_decr_mode::*;
 pub use self::H5C_cache_flash_incr_mode::*;
 pub use self::H5C_cache_incr_mode::*;

--- a/hdf5-sys/src/h5d.rs
+++ b/hdf5-sys/src/h5d.rs
@@ -1,3 +1,4 @@
+//! Creating and manipulating scientific datasets
 pub use self::H5D_alloc_time_t::*;
 pub use self::H5D_fill_time_t::*;
 pub use self::H5D_fill_value_t::*;

--- a/hdf5-sys/src/h5e.rs
+++ b/hdf5-sys/src/h5e.rs
@@ -1,3 +1,4 @@
+//! Functions for handling errors that occur within HDF5
 use std::mem;
 
 pub use self::H5E_direction_t::*;

--- a/hdf5-sys/src/h5f.rs
+++ b/hdf5-sys/src/h5f.rs
@@ -1,3 +1,4 @@
+//! Creating and manipulating HDF5 files
 use std::mem;
 
 pub use self::H5F_close_degree_t::*;

--- a/hdf5-sys/src/h5fd.rs
+++ b/hdf5-sys/src/h5fd.rs
@@ -1,3 +1,4 @@
+//! File drivers
 use std::mem;
 
 pub use self::H5FD_file_image_op_t::*;

--- a/hdf5-sys/src/h5g.rs
+++ b/hdf5-sys/src/h5g.rs
@@ -1,3 +1,4 @@
+//! Creating and manipulating groups of objects inside an HDF5 file
 use std::mem;
 
 pub use self::H5G_storage_type_t::*;

--- a/hdf5-sys/src/h5i.rs
+++ b/hdf5-sys/src/h5i.rs
@@ -1,3 +1,4 @@
+//! Manipulating object identifiers and object names
 pub use self::H5I_type_t::*;
 
 use crate::internal_prelude::*;

--- a/hdf5-sys/src/h5l.rs
+++ b/hdf5-sys/src/h5l.rs
@@ -1,3 +1,4 @@
+//! Creating and manipulating links within an HDF5 group
 use std::mem;
 
 pub use self::H5L_type_t::*;

--- a/hdf5-sys/src/h5mm.rs
+++ b/hdf5-sys/src/h5mm.rs
@@ -1,3 +1,4 @@
+//! Memory managment
 use crate::internal_prelude::*;
 
 pub type H5MM_allocate_t =

--- a/hdf5-sys/src/h5o.rs
+++ b/hdf5-sys/src/h5o.rs
@@ -1,3 +1,4 @@
+//! Manipulating objects in an HDF5 file
 use std::mem;
 
 pub use self::H5O_mcdt_search_ret_t::*;

--- a/hdf5-sys/src/h5o.rs
+++ b/hdf5-sys/src/h5o.rs
@@ -9,6 +9,12 @@ pub use {
 };
 #[cfg(hdf5_1_12_0)]
 pub use {H5O_info2_t as H5O_info_t, H5O_iterate2_t as H5O_iterate_t};
+#[cfg(not(hdf5_1_10_3))]
+pub use {
+    H5Oget_info1 as H5Oget_info, H5Oget_info_by_idx1 as H5Oget_info_by_idx,
+    H5Oget_info_by_name1 as H5Oget_info_by_name, H5Ovisit1 as H5Ovisit,
+    H5Ovisit_by_name1 as H5Ovisit_by_name,
+};
 
 use crate::internal_prelude::*;
 
@@ -201,19 +207,24 @@ pub type H5O_mcdt_search_cb_t =
 
 #[cfg(not(hdf5_1_10_3))]
 extern "C" {
-    pub fn H5Oget_info(loc_id: hid_t, oinfo: *mut H5O_info1_t) -> herr_t;
-    pub fn H5Oget_info_by_name(
+    #[link_name = "H5Oget_info"]
+    pub fn H5Oget_info1(loc_id: hid_t, oinfo: *mut H5O_info1_t) -> herr_t;
+    #[link_name = "H5Oget_info_by_name"]
+    pub fn H5Oget_info_by_name1(
         loc_id: hid_t, name: *const c_char, oinfo: *mut H5O_info1_t, lapl_id: hid_t,
     ) -> herr_t;
-    pub fn H5Oget_info_by_idx(
+    #[link_name = "H5Oget_info_by_idx"]
+    pub fn H5Oget_info_by_idx1(
         loc_id: hid_t, group_name: *const c_char, idx_type: H5_index_t, order: H5_iter_order_t,
         n: hsize_t, oinfo: *mut H5O_info1_t, lapl_id: hid_t,
     ) -> herr_t;
-    pub fn H5Ovisit(
+    #[link_name = "H5Ovisit"]
+    pub fn H5Ovisit1(
         obj_id: hid_t, idx_type: H5_index_t, order: H5_iter_order_t, op: H5O_iterate1_t,
         op_data: *mut c_void,
     ) -> herr_t;
-    pub fn H5Ovisit_by_name(
+    #[link_name = "H5Ovisit_by_name"]
+    pub fn H5Ovisit_by_name1(
         loc_id: hid_t, obj_name: *const c_char, idx_type: H5_index_t, order: H5_iter_order_t,
         op: H5O_iterate1_t, op_data: *mut c_void, lapl_id: hid_t,
     ) -> herr_t;
@@ -353,7 +364,7 @@ extern "C" {
 pub const H5O_MAX_TOKEN_SIZE: usize = 16;
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg(hdf5_1_12_0)]
 pub struct H5O_token_t {
     __data: [u8; H5O_MAX_TOKEN_SIZE],
@@ -370,15 +381,15 @@ impl Default for H5O_token_t {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct H5O_info2_t {
-    fileno: c_ulong,
-    token: H5O_token_t,
-    type_: H5O_type_t,
-    rc: c_uint,
-    atime: time_t,
-    mtime: time_t,
-    ctime: time_t,
-    btime: time_t,
-    num_attrs: hsize_t,
+    pub fileno: c_ulong,
+    pub token: H5O_token_t,
+    pub type_: H5O_type_t,
+    pub rc: c_uint,
+    pub atime: time_t,
+    pub mtime: time_t,
+    pub ctime: time_t,
+    pub btime: time_t,
+    pub num_attrs: hsize_t,
 }
 
 #[cfg(hdf5_1_12_0)]

--- a/hdf5-sys/src/h5p.rs
+++ b/hdf5-sys/src/h5p.rs
@@ -1,3 +1,4 @@
+//! Creating and manipulating property lists to control HDF5 library behaviour
 use crate::internal_prelude::*;
 
 use crate::h5ac::H5AC_cache_config_t;

--- a/hdf5-sys/src/h5pl.rs
+++ b/hdf5-sys/src/h5pl.rs
@@ -1,3 +1,4 @@
+//! Programmatically controlling dynamically loaded plugins
 use crate::internal_prelude::*;
 
 #[cfg(hdf5_1_8_15)]

--- a/hdf5-sys/src/h5r.rs
+++ b/hdf5-sys/src/h5r.rs
@@ -1,3 +1,4 @@
+//! Creating and manipulating references to specific objects and data regions in an HDF5 file
 pub use self::H5R_type_t::*;
 #[cfg(not(hdf5_1_10_0))]
 pub use H5Rdereference1 as H5Rdereference;

--- a/hdf5-sys/src/h5s.rs
+++ b/hdf5-sys/src/h5s.rs
@@ -1,3 +1,4 @@
+//! Creating and manipulating dataspaces in which to store elements of a dataset
 pub use self::H5S_class_t::*;
 pub use self::H5S_sel_type::*;
 pub use self::H5S_seloper_t::*;

--- a/hdf5-sys/src/h5t.rs
+++ b/hdf5-sys/src/h5t.rs
@@ -1,3 +1,4 @@
+//! Creating and manipulating datatypes which describe elements of a dataset
 use std::mem;
 
 pub use self::H5T_bkg_t::*;

--- a/hdf5-sys/src/h5vl.rs
+++ b/hdf5-sys/src/h5vl.rs
@@ -1,3 +1,4 @@
+//! Using the Virtual Object Layer
 #![cfg(hdf5_1_12_0)]
 use crate::internal_prelude::*;
 

--- a/hdf5-sys/src/h5z.rs
+++ b/hdf5-sys/src/h5z.rs
@@ -1,3 +1,4 @@
+//! Configuring filters that process data during I/O operation
 use std::mem;
 
 pub use self::H5Z_EDC_t::*;

--- a/hdf5-sys/src/lib.rs
+++ b/hdf5-sys/src/lib.rs
@@ -1,3 +1,4 @@
+//! Rust bindings to the `hdf5` library for reading and writing data to and from storage
 #![allow(non_camel_case_types, non_snake_case, dead_code, deprecated)]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::unreadable_literal))]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::missing_safety_doc))]

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -54,15 +54,17 @@ impl Handle {
         self.id
     }
 
+    /// Increment the reference count of the handle
     pub fn incref(&self) {
         if is_valid_user_id(self.id()) {
             h5lock!(H5Iinc_ref(self.id()));
         }
     }
 
-    /// An object should not be decreffed unless it has an
-    /// associated incref
-    pub unsafe fn decref(&self) {
+    /// Decrease the reference count of the handle
+    ///
+    /// This function should only be used if `incref` has been used
+    pub fn decref(&self) {
         h5lock!({
             if self.is_valid_id() {
                 H5Idec_ref(self.id());
@@ -80,7 +82,8 @@ impl Handle {
         is_valid_id(self.id())
     }
 
-    pub(crate) fn refcount(&self) -> u32 {
+    /// Return the reference count of the object
+    pub fn refcount(&self) -> u32 {
         refcount(self.id).unwrap_or(0) as u32
     }
 }

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -1,9 +1,3 @@
-use std::collections::HashMap;
-use std::sync::Arc;
-
-use lazy_static::lazy_static;
-use parking_lot::{Mutex, RwLock};
-
 use hdf5_sys::h5i::{H5I_type_t, H5Idec_ref, H5Iget_type, H5Iinc_ref, H5Iis_valid};
 
 use crate::internal_prelude::*;
@@ -20,6 +14,10 @@ pub fn get_id_type(id: hid_t) -> H5I_type_t {
     })
 }
 
+pub(crate) fn refcount(id: hid_t) -> Result<hsize_t> {
+    h5call!(hdf5_sys::h5i::H5Iget_ref(id)).map(|x| x as _)
+}
+
 pub fn is_valid_id(id: hid_t) -> bool {
     h5lock!({
         let tp = get_id_type(id);
@@ -31,44 +29,17 @@ pub fn is_valid_user_id(id: hid_t) -> bool {
     h5lock!({ H5Iis_valid(id) == 1 })
 }
 
-struct Registry {
-    registry: Mutex<HashMap<hid_t, Arc<RwLock<hid_t>>>>,
-}
-
-impl Default for Registry {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Registry {
-    pub fn new() -> Self {
-        Self { registry: Mutex::new(HashMap::new()) }
-    }
-
-    pub fn new_handle(&self, id: hid_t) -> Arc<RwLock<hid_t>> {
-        let mut registry = self.registry.lock();
-        let handle = registry.entry(id).or_insert_with(|| Arc::new(RwLock::new(id)));
-        if *handle.read() != id {
-            // an id may be left dangling by previous invalidation of a linked handle
-            *handle = Arc::new(RwLock::new(id));
-        }
-        handle.clone()
-    }
-}
-
+/// A handle to a `hdf5` object
 pub struct Handle {
-    id: Arc<RwLock<hid_t>>,
+    id: hid_t,
 }
 
 impl Handle {
+    /// Take ownership of the object id
     pub fn try_new(id: hid_t) -> Result<Self> {
-        lazy_static! {
-            static ref REGISTRY: Registry = Registry::new();
-        }
         h5lock!({
             if is_valid_user_id(id) {
-                Ok(Self { id: REGISTRY.new_handle(id) })
+                Ok(Self { id })
             } else {
                 Err(From::from(format!("Invalid handle id: {}", id)))
             }
@@ -76,15 +47,11 @@ impl Handle {
     }
 
     pub fn invalid() -> Self {
-        Self { id: Arc::new(RwLock::new(H5I_INVALID_HID)) }
+        Self { id: H5I_INVALID_HID }
     }
 
     pub fn id(&self) -> hid_t {
-        *self.id.read()
-    }
-
-    pub fn invalidate(&self) {
-        *self.id.write() = H5I_INVALID_HID;
+        self.id
     }
 
     pub fn incref(&self) {
@@ -93,16 +60,14 @@ impl Handle {
         }
     }
 
-    pub fn decref(&self) {
+    /// An object should not be decreffed unless it has an
+    /// associated incref
+    pub unsafe fn decref(&self) {
         h5lock!({
             if self.is_valid_id() {
                 H5Idec_ref(self.id());
             }
-            // must invalidate all linked IDs because the library reuses them internally
-            if !self.is_valid_user_id() && !self.is_valid_id() {
-                self.invalidate();
-            }
-        });
+        })
     }
 
     /// Returns `true` if the object has a valid unlocked identifier (`false` for pre-defined
@@ -115,10 +80,8 @@ impl Handle {
         is_valid_id(self.id())
     }
 
-    pub fn decref_full(&self) {
-        while self.is_valid_user_id() {
-            self.decref();
-        }
+    pub(crate) fn refcount(&self) -> u32 {
+        refcount(self.id).unwrap_or(0) as u32
     }
 }
 

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -69,7 +69,7 @@ impl Handle {
             if self.is_valid_id() {
                 H5Idec_ref(self.id());
             }
-        })
+        });
     }
 
     /// Returns `true` if the object has a valid unlocked identifier (`false` for pre-defined

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -24,8 +24,8 @@ pub use self::{
     dataspace::Dataspace,
     datatype::{Conversion, Datatype},
     file::{File, FileBuilder, OpenMode},
-    group::Group,
-    location::Location,
+    group::{Group, LinkInfo, LinkType},
+    location::{Location, LocationInfo, LocationToken, LocationType},
     object::Object,
     plist::PropertyList,
 };

--- a/src/hl/file.rs
+++ b/src/hl/file.rs
@@ -516,6 +516,7 @@ pub mod tests {
                 assert!(crate::handle::refcount(fileid).is_err());
                 assert!(crate::handle::refcount(groupid).is_err());
                 assert!(!group.is_valid());
+                drop(group);
             });
         });
     }

--- a/src/hl/file.rs
+++ b/src/hl/file.rs
@@ -5,8 +5,7 @@ use std::path::Path;
 use hdf5_sys::h5f::{
     H5Fclose, H5Fcreate, H5Fflush, H5Fget_access_plist, H5Fget_create_plist, H5Fget_filesize,
     H5Fget_freespace, H5Fget_intent, H5Fget_obj_count, H5Fget_obj_ids, H5Fopen, H5F_ACC_DEFAULT,
-    H5F_ACC_EXCL, H5F_ACC_RDONLY, H5F_ACC_RDWR, H5F_ACC_TRUNC, H5F_OBJ_ALL, H5F_OBJ_FILE,
-    H5F_SCOPE_LOCAL,
+    H5F_ACC_EXCL, H5F_ACC_RDONLY, H5F_ACC_RDWR, H5F_ACC_TRUNC, H5F_SCOPE_LOCAL,
 };
 
 use crate::hl::plist::{
@@ -133,6 +132,7 @@ impl File {
     }
 
     /// Returns objects IDs of the contained objects. NOTE: these are borrowed references.
+    #[allow(unused)]
     fn get_obj_ids(&self, types: c_uint) -> Vec<hid_t> {
         h5lock!({
             let count = h5call!(H5Fget_obj_count(self.id(), types)).unwrap_or(0) as size_t;
@@ -151,26 +151,11 @@ impl File {
     }
 
     /// Closes the file and invalidates all open handles for contained objects.
-    pub fn close(self) {
-        h5lock!({
-            let file_ids = self.get_obj_ids(H5F_OBJ_FILE);
-            let object_ids = self.get_obj_ids(H5F_OBJ_ALL & !H5F_OBJ_FILE);
-            for file_id in &file_ids {
-                if let Ok(handle) = Handle::try_new(*file_id) {
-                    handle.decref_full();
-                }
-            }
-            for object_id in &object_ids {
-                if let Ok(handle) = Handle::try_new(*object_id) {
-                    handle.decref_full();
-                }
-            }
-            H5Fclose(self.id());
-            while self.is_valid() {
-                self.0.decref();
-            }
-            self.0.decref();
-        });
+    pub fn close(self) -> Result<()> {
+        let id = self.id();
+        // Ensure we only decref once
+        std::mem::forget(self.0);
+        h5call!(H5Fclose(id)).map(|_| ())
     }
 
     /// Returns a copy of the file access property list.
@@ -500,6 +485,76 @@ pub mod tests {
     }
 
     #[test]
+    fn test_strong_close() {
+        use crate::hl::plist::file_access::FileCloseDegree;
+        with_tmp_path(|path| {
+            let file = File::with_options()
+                .with_fapl(|fapl| fapl.fclose_degree(FileCloseDegree::Strong))
+                .create(&path)
+                .unwrap();
+            assert_eq!(file.refcount(), 1);
+            let fileid = file.id();
+
+            let group = file.create_group("foo").unwrap();
+            assert_eq!(file.refcount(), 1);
+            assert_eq!(group.refcount(), 1);
+
+            let file_copy = group.file().unwrap();
+            assert_eq!(group.refcount(), 1);
+            assert_eq!(file.refcount(), 2);
+            assert_eq!(file_copy.refcount(), 2);
+
+            drop(file);
+            assert_eq!(crate::handle::refcount(fileid).unwrap(), 1);
+            assert_eq!(group.refcount(), 1);
+            assert_eq!(file_copy.refcount(), 1);
+
+            h5lock!({
+                // Lock to ensure fileid does not get overwritten
+                let groupid = group.id();
+                drop(file_copy);
+                assert!(crate::handle::refcount(fileid).is_err());
+                assert!(crate::handle::refcount(groupid).is_err());
+                assert!(!group.is_valid());
+            });
+        });
+    }
+
+    #[test]
+    fn test_weak_close() {
+        use crate::hl::plist::file_access::FileCloseDegree;
+        with_tmp_path(|path| {
+            let file = File::with_options()
+                .with_fapl(|fapl| fapl.fclose_degree(FileCloseDegree::Weak))
+                .create(&path)
+                .unwrap();
+            assert_eq!(file.refcount(), 1);
+            let fileid = file.id();
+
+            let group = file.create_group("foo").unwrap();
+            assert_eq!(file.refcount(), 1);
+            assert_eq!(group.refcount(), 1);
+
+            let file_copy = group.file().unwrap();
+            assert_eq!(group.refcount(), 1);
+            assert_eq!(file.refcount(), 2);
+            assert_eq!(file_copy.refcount(), 2);
+
+            drop(file);
+            assert_eq!(crate::handle::refcount(fileid).unwrap(), 1);
+            assert_eq!(group.refcount(), 1);
+            assert_eq!(file_copy.refcount(), 1);
+
+            h5lock!({
+                // Lock to ensure fileid does not get overwritten
+                drop(file_copy);
+                assert!(crate::handle::refcount(fileid).is_err());
+            });
+            assert_eq!(group.refcount(), 1);
+        });
+    }
+
+    #[test]
     pub fn test_close_automatic() {
         // File going out of scope should just close its own handle
         with_tmp_path(|path| {
@@ -513,26 +568,13 @@ pub mod tests {
     }
 
     #[test]
-    pub fn test_close_manual() {
-        // File::close() should close handles of all related objects
-        with_tmp_path(|path| {
-            let file = File::create(&path).unwrap();
-            let group = file.create_group("foo").unwrap();
-            let file_copy = group.file().unwrap();
-            file.close();
-            assert!(!group.is_valid());
-            assert!(!file_copy.is_valid());
-        })
-    }
-
-    #[test]
     pub fn test_core_fd_non_filebacked() {
         with_tmp_path(|path| {
             let file =
                 FileBuilder::new().with_fapl(|p| p.core_filebacked(false)).create(&path).unwrap();
             file.create_group("x").unwrap();
             assert!(file.is_valid());
-            file.close();
+            file.close().unwrap();
             assert!(fs::metadata(&path).is_err());
             assert_err!(
                 FileBuilder::new().with_fapl(|p| p.core()).open(&path),
@@ -548,7 +590,7 @@ pub mod tests {
                 FileBuilder::new().with_fapl(|p| p.core_filebacked(true)).create(&path).unwrap();
             assert!(file.is_valid());
             file.create_group("bar").unwrap();
-            file.close();
+            file.close().unwrap();
             assert!(fs::metadata(&path).is_ok());
             File::open(&path).unwrap().group("bar").unwrap();
         })
@@ -594,8 +636,8 @@ pub mod tests {
             let path = dir.join("qwe.h5");
             let file = File::create(&path).unwrap();
             assert_eq!(format!("{:?}", file), "<HDF5 file: \"qwe.h5\" (read/write)>");
-            let root = file.file().unwrap();
-            file.close();
+            file.close().unwrap();
+            let root = File::from_handle(Handle::invalid());
             assert_eq!(format!("{:?}", root), "<HDF5 file: invalid id>");
             let file = File::open(&path).unwrap();
             assert_eq!(format!("{:?}", file), "<HDF5 file: \"qwe.h5\" (read-only)>");

--- a/src/hl/group.rs
+++ b/src/hl/group.rs
@@ -427,6 +427,9 @@ pub mod tests {
             h5lock!({
                 file.close().unwrap();
                 assert_eq!(format!("{:?}", a), "<HDF5 group: invalid id>");
+                drop(a);
+                drop(ab);
+                drop(abc);
             })
         })
     }

--- a/src/hl/location.rs
+++ b/src/hl/location.rs
@@ -1,14 +1,27 @@
 use std::fmt::{self, Debug};
+use std::mem::MaybeUninit;
 use std::ops::Deref;
 use std::ptr;
 
 #[allow(deprecated)]
 use hdf5_sys::h5o::H5Oset_comment;
+#[cfg(hdf5_1_10_3)]
+use hdf5_sys::h5o::H5O_INFO_BASIC;
+#[cfg(hdf5_1_12_0)]
+use hdf5_sys::h5o::{
+    H5O_info2_t, H5O_token_t, H5Oget_info3, H5Oget_info_by_name3, H5Oopen_by_token,
+};
+#[cfg(not(hdf5_1_10_3))]
+use hdf5_sys::h5o::{H5Oget_info1, H5Oget_info_by_name1};
+#[cfg(all(hdf5_1_10_3, not(hdf5_1_12_0)))]
+use hdf5_sys::h5o::{H5Oget_info2, H5Oget_info_by_name2};
+#[cfg(not(hdf5_1_12_0))]
+use hdf5_sys::{h5::haddr_t, h5o::H5O_info1_t, h5o::H5Oopen_by_addr};
 use hdf5_sys::{
     h5a::H5Aopen,
     h5f::H5Fget_name,
     h5i::{H5Iget_file_id, H5Iget_name},
-    h5o::H5Oget_comment,
+    h5o::{H5O_type_t, H5Oget_comment},
 };
 
 use crate::internal_prelude::*;
@@ -111,6 +124,148 @@ impl Location {
     pub fn attr_names(&self) -> Result<Vec<String>> {
         Attribute::attr_names(self)
     }
+
+    pub fn get_info(&self) -> Result<LocationInfo> {
+        H5O_get_info(self.id())
+    }
+
+    pub fn loc_type(&self) -> Result<LocationType> {
+        Ok(self.get_info()?.loc_type)
+    }
+
+    pub fn get_info_by_name(&self, name: &str) -> Result<LocationInfo> {
+        let name = to_cstring(name)?;
+        H5O_get_info_by_name(self.id(), name.as_ptr())
+    }
+
+    pub fn open_by_token(&self, token: LocationToken) -> Result<Self> {
+        H5O_open_by_token(self.id(), token)
+    }
+}
+
+#[cfg(hdf5_1_12_0)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LocationToken(H5O_token_t);
+
+#[cfg(not(hdf5_1_12_0))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LocationToken(haddr_t);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LocationType {
+    Group,
+    Dataset,
+    NamedDatatype,
+    #[cfg(hdf5_1_12_0)]
+    TypeMap,
+}
+
+impl From<H5O_type_t> for LocationType {
+    fn from(loc_type: H5O_type_t) -> Self {
+        // we're assuming here that if a C API call returns H5O_TYPE_UNKNOWN (-1), then
+        // an error has occured anyway and has been pushed on the error stack so we'll
+        // catch it, and the value of -1 will never reach this conversion function
+        match loc_type {
+            H5O_type_t::H5O_TYPE_DATASET => Self::Dataset,
+            H5O_type_t::H5O_TYPE_NAMED_DATATYPE => Self::NamedDatatype,
+            #[cfg(hdf5_1_12_0)]
+            H5O_type_t::H5O_TYPE_MAP => Self::TypeMap,
+            _ => Self::Group, // see the comment above
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// Information about a [`Location`]
+pub struct LocationInfo {
+    pub fileno: u64,
+    pub token: LocationToken,
+    pub loc_type: LocationType,
+    pub refcount: usize,
+    /// Not available when requesting only basic info
+    atime: i64,
+    /// Not available when requesting only basic info
+    mtime: i64,
+    /// Not available when requesting only basic info
+    ctime: i64,
+    /// Not available when requesting only basic info
+    btime: i64,
+    /// Not available when requesting only basic info
+    num_attrs: usize,
+}
+
+#[cfg(not(hdf5_1_12_0))]
+impl From<H5O_info1_t> for LocationInfo {
+    fn from(info: H5O_info1_t) -> Self {
+        Self {
+            fileno: info.fileno as _,
+            token: LocationToken(info.addr),
+            loc_type: info.type_.into(),
+            refcount: info.rc as _,
+            atime: info.atime as _,
+            mtime: info.mtime as _,
+            ctime: info.ctime as _,
+            btime: info.btime as _,
+            num_attrs: info.num_attrs as _,
+        }
+    }
+}
+
+#[cfg(hdf5_1_12_0)]
+impl From<H5O_info2_t> for LocationInfo {
+    fn from(info: H5O_info2_t) -> Self {
+        Self {
+            fileno: info.fileno as _,
+            token: LocationToken(info.token),
+            loc_type: info.type_.into(),
+            refcount: info.rc as _,
+            atime: info.atime as _,
+            mtime: info.mtime as _,
+            ctime: info.ctime as _,
+            btime: info.btime as _,
+            num_attrs: info.num_attrs as _,
+        }
+    }
+}
+
+#[allow(non_snake_case)]
+fn H5O_get_info(loc_id: hid_t) -> Result<LocationInfo> {
+    let mut info_buf = MaybeUninit::uninit();
+    let info_ptr = info_buf.as_mut_ptr();
+    #[cfg(hdf5_1_12_0)]
+    h5call!(H5Oget_info3(loc_id, info_ptr, H5O_INFO_BASIC))?;
+    #[cfg(all(hdf5_1_10_3, not(hdf5_1_12_0)))]
+    h5call!(H5Oget_info2(loc_id, info_ptr, H5O_INFO_BASIC))?;
+    #[cfg(not(hdf5_1_10_3))]
+    h5call!(H5Oget_info1(loc_id, info_ptr))?;
+    let info = unsafe { info_buf.assume_init() };
+    Ok(info.into())
+}
+
+#[allow(non_snake_case)]
+fn H5O_get_info_by_name(loc_id: hid_t, name: *const c_char) -> Result<LocationInfo> {
+    let mut info_buf = MaybeUninit::uninit();
+    let info_ptr = info_buf.as_mut_ptr();
+    #[cfg(hdf5_1_12_0)]
+    h5call!(H5Oget_info_by_name3(loc_id, name, info_ptr, H5O_INFO_BASIC, H5P_DEFAULT))?;
+    #[cfg(all(hdf5_1_10_3, not(hdf5_1_12_0)))]
+    h5call!(H5Oget_info_by_name2(loc_id, name, info_ptr, H5O_INFO_BASIC, H5P_DEFAULT))?;
+    #[cfg(not(hdf5_1_10_3))]
+    h5call!(H5Oget_info_by_name1(loc_id, name, info_ptr, H5P_DEFAULT))?;
+    let info = unsafe { info_buf.assume_init() };
+    Ok(info.into())
+}
+
+#[allow(non_snake_case)]
+fn H5O_open_by_token(loc_id: hid_t, token: LocationToken) -> Result<Location> {
+    #[cfg(not(hdf5_1_12_0))]
+    {
+        Location::from_id(h5call!(H5Oopen_by_addr(loc_id, token.0))?)
+    }
+    #[cfg(hdf5_1_12_0)]
+    {
+        Location::from_id(h5call!(H5Oopen_by_token(loc_id, token.0))?)
+    }
 }
 
 #[cfg(test)]
@@ -147,6 +302,42 @@ pub mod tests {
             assert_eq!(file.comment().unwrap(), "foo");
             assert!(file.clear_comment().is_ok());
             assert!(file.comment().is_none());
+        })
+    }
+
+    #[test]
+    pub fn test_location_info() {
+        with_tmp_file(|file| {
+            let token;
+            {
+                let group = file.create_group("group").unwrap();
+                let info = group.get_info().unwrap();
+                assert_eq!(info.refcount, 1);
+                assert_eq!(info.loc_type, LocationType::Group);
+                token = info.token;
+            }
+            let group = file.open_by_token(token).unwrap();
+            assert_eq!(group.name(), "/group");
+            let token;
+            {
+                let var = file.new_dataset::<i8>().create("var").unwrap();
+                var.new_attr::<i16>().create("attr").unwrap();
+                let info = var.get_info().unwrap();
+                assert_eq!(info.refcount, 1);
+                assert_eq!(info.loc_type, LocationType::Dataset);
+                token = info.token;
+            }
+            let var = file.open_by_token(token).unwrap();
+            assert_eq!(var.name(), "/var");
+
+            let info = file.get_info_by_name("group").unwrap();
+            let group = file.open_by_token(info.token).unwrap();
+            assert_eq!(group.name(), "/group");
+            let info = file.get_info_by_name("var").unwrap();
+            let var = file.open_by_token(info.token).unwrap();
+            assert_eq!(var.name(), "/var");
+
+            assert!(file.get_info_by_name("gibberish").is_err());
         })
     }
 }

--- a/src/hl/object.rs
+++ b/src/hl/object.rs
@@ -124,11 +124,14 @@ pub mod tests {
         obj.decref();
         assert_eq!(obj.refcount(), 1);
         obj.decref();
-        obj.decref();
-        assert_eq!(obj.refcount(), 0);
-        assert!(!obj.is_valid());
-        assert!(!is_valid_user_id(obj.id()));
-        assert!(!is_valid_id(obj.id()));
+        h5lock!({
+            obj.decref();
+            assert_eq!(obj.refcount(), 0);
+            assert!(!obj.is_valid());
+            assert!(!is_valid_user_id(obj.id()));
+            assert!(!is_valid_id(obj.id()));
+            drop(obj);
+        });
     }
 
     #[test]
@@ -166,6 +169,8 @@ pub mod tests {
             obj.decref();
             assert!(!obj.is_valid());
             assert!(!obj2.is_valid());
+            drop(obj);
+            drop(obj2);
         });
     }
 }

--- a/src/hl/plist/file_access.rs
+++ b/src/hl/plist/file_access.rs
@@ -1543,6 +1543,9 @@ impl FileAccess {
             }
             *layout.get_mut(i - 1) = 0xff - mapping[j];
         }
+        for &memb_name in &memb_name {
+            crate::util::h5_free_memory(memb_name as *mut _);
+        }
         let relax = relax > 0;
         let drv = MultiDriver { files, layout, relax };
         drv.validate().map(|_| drv)

--- a/src/hl/plist/file_access.rs
+++ b/src/hl/plist/file_access.rs
@@ -1026,6 +1026,11 @@ impl FileAccessBuilder {
         Ok(builder)
     }
 
+    /// Sets the file close degree
+    ///
+    /// If called with `FileCloseDegree::Strong`, the programmer is responsible
+    /// for closing all items before closing the file. Failure to do so might
+    /// invalidate newly created objects.
     pub fn fclose_degree(&mut self, fc_degree: FileCloseDegree) -> &mut Self {
         self.fclose_degree = Some(fc_degree);
         self
@@ -1374,6 +1379,8 @@ impl FileAccessBuilder {
         if let Some(v) = self.chunk_cache {
             h5try!(H5Pset_cache(id, 0, v.nslots as _, v.nbytes as _, v.w0 as _));
         }
+        // The default is to use CLOSE_SEMI or CLOSE_WEAK, depending on VFL driver.
+        // Both of these are unproblematic for our ownership
         if let Some(v) = self.fclose_degree {
             h5try!(H5Pset_fclose_degree(id, v.into()));
         }

--- a/src/hl/selection.rs
+++ b/src/hl/selection.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::convert::{TryFrom, TryInto};
 use std::fmt::{self, Display};
 use std::mem;
 use std::ops::{Deref, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
@@ -106,15 +107,6 @@ fn check_coords(coords: &Array2<Ix>, shape: &[Ix]) -> Result<()> {
         }
     }
     Ok(())
-}
-
-#[inline]
-fn abs_index(len: usize, index: isize) -> isize {
-    if index < 0 {
-        (len as isize) + index
-    } else {
-        index
-    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -227,30 +219,98 @@ impl RawSelection {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// A selector of a one-dimensional array
+///
+/// The following examples will use an array of 11 elements
+/// to illustrate the various selections. The active elements
+/// are marked with an `s`.
+/// ```text
+/// // An array of 11 elements
+/// x x x x x x x x x x x
+/// ```
+///
+/// ```text
+/// Index(4)
+/// _ _ _ _ s _ _ _ _ _ _
+/// ```
+/// ```text
+/// Slice { start: 0, step: 3, end: 4, block: 1 }
+/// s _ _ s _ _ _ _ _ _ _
+/// ```
+/// ```text
+/// SliceTo { start: 2, step: 3, end: 8, block: 1 }
+/// _ _ s _ _ s _ _ _ _ _
+/// ```
+/// ```text
+/// SliceCount { start: 1, step: 3, count: 2, block: 1 }
+/// _ s _ _ s _ _ s _ _ _
+/// ```
+/// ```text
+/// Unlimited { start: 0, step: 3, block: 1 }
+/// s _ _ s _ _ s _ _ s _
+/// ```
+/// ```text
+/// Unlimited { start: 2, step: 3, block: 1 }
+/// _ _ s _ _ s _ _ s _ _
+/// ```
+/// ```text
+/// Unlimited { start: 0, step: 4, block: 2 }
+/// s s _ _ s s _ _ s s _
+/// ```
+///
+/// See also [`this hdf5 tutorial`](https://support.hdfgroup.org/HDF5/Tutor/select.html)
+/// for more information on hyperslab selections.
+#[derive(Clone, Copy, Debug, Eq)]
 pub enum SliceOrIndex {
-    Index(isize),
-    Slice { start: isize, step: isize, end: Option<isize>, block: bool },
-    Unlimited { start: isize, step: isize, block: bool },
+    /// A single index
+    Index(Ix),
+    /// Up to the given index
+    SliceTo { start: Ix, step: Ix, end: Ix, block: Ix },
+    /// The given count of elements
+    SliceCount { start: Ix, step: Ix, count: Ix, block: Ix },
+    /// An unlimited hyperslab
+    Unlimited { start: Ix, step: Ix, block: Ix },
+}
+
+impl PartialEq for SliceOrIndex {
+    fn eq(&self, other: &Self) -> bool {
+        use SliceOrIndex::{Index, SliceCount, SliceTo, Unlimited};
+        match (self, other) {
+            (Index(s), Index(o)) => s == o,
+            (
+                SliceTo { start: sstart, step: sstep, end: send, block: sblock },
+                SliceTo { start: ostart, step: ostep, end: oend, block: oblock },
+            ) => (sstart == ostart) & (sstep == ostep) & (send == oend) & (sblock == oblock),
+            (
+                SliceCount { start: sstart, step: sstep, count: scount, block: sblock },
+                SliceCount { start: ostart, step: ostep, count: ocount, block: oblock },
+            ) => (sstart == ostart) & (sstep == ostep) & (scount == ocount) & (sblock == oblock),
+            (
+                Unlimited { start: sstart, step: sstep, block: sblock },
+                Unlimited { start: ostart, step: ostep, block: oblock },
+            ) => (sstart == ostart) & (sstep == ostep) & (sblock == oblock),
+            (
+                SliceTo { start: sstart, step: sstep, end: _, block: sblock },
+                SliceCount { start: ostart, step: ostep, count: ocount, block: oblock },
+            ) => {
+                if (sstart != ostart) | (sstep != ostep) | (sblock != oblock) {
+                    return false;
+                }
+                self.count().unwrap() == *ocount
+            }
+            (SliceCount { .. }, SliceTo { .. }) => other == self,
+            _ => false,
+        }
+    }
 }
 
 impl SliceOrIndex {
     pub fn to_unlimited(self) -> Result<Self> {
         Ok(match self {
             Self::Index(_) => fail!("Cannot make index selection unlimited"),
-            Self::Slice { end: Some(_), .. } => {
-                fail!("Cannot make bounded slice unlimited")
-            }
-            Self::Slice { start, step, end: None, block } => Self::Unlimited { start, step, block },
-            Self::Unlimited { .. } => self,
-        })
-    }
-
-    pub fn to_block(self) -> Result<Self> {
-        Ok(match self {
-            Self::Index(_) => fail!("Cannot make index selection block-like"),
-            Self::Slice { start, step, end, .. } => Self::Slice { start, step, end, block: true },
-            Self::Unlimited { start, step, .. } => Self::Unlimited { start, step, block: true },
+            Self::SliceTo { start, step, block, .. }
+            | Self::SliceCount { start, step, block, .. }
+            | Self::Unlimited { start, step, block } => Self::Unlimited { start, step, block },
         })
     }
 
@@ -259,24 +319,210 @@ impl SliceOrIndex {
     }
 
     pub fn is_slice(self) -> bool {
-        matches!(self, Self::Slice { .. })
+        matches!(self, Self::SliceTo { .. } | Self::SliceCount { .. } | Self::Unlimited { .. })
     }
 
     pub fn is_unlimited(self) -> bool {
         matches!(self, Self::Unlimited { .. })
     }
+
+    fn set_blocksize(self, blocksize: Ix) -> Result<Self> {
+        Ok(match self {
+            Self::Index(_) => fail!("Cannot set blocksize for index selection"),
+            Self::SliceTo { start, step, end, .. } => {
+                Self::SliceTo { start, step, end, block: blocksize }
+            }
+            Self::SliceCount { start, step, count, .. } => {
+                Self::SliceCount { start, step, count, block: blocksize }
+            }
+            Self::Unlimited { start, step, .. } => {
+                Self::Unlimited { start, step, block: blocksize }
+            }
+        })
+    }
+
+    /// Number of elements contained in the `SliceOrIndex`
+    fn count(self) -> Option<usize> {
+        use SliceOrIndex::{Index, SliceCount, SliceTo, Unlimited};
+        match self {
+            Index(_) => Some(1),
+            SliceTo { start, step, end, block } => {
+                Some((start + block.saturating_sub(1)..end).step_by(step).count())
+            }
+            SliceCount { count, .. } => Some(count),
+            Unlimited { .. } => None,
+        }
+    }
 }
 
-#[allow(clippy::fallible_impl_from)]
-impl<T: Into<ndarray::SliceInfoElem>> From<T> for SliceOrIndex {
-    fn from(slice: T) -> Self {
-        match slice.into() {
-            ndarray::SliceInfoElem::Index(index) => Self::Index(index),
+impl TryFrom<ndarray::SliceInfoElem> for SliceOrIndex {
+    type Error = Error;
+    fn try_from(slice: ndarray::SliceInfoElem) -> Result<Self, Self::Error> {
+        Ok(match slice {
+            ndarray::SliceInfoElem::Index(index) => match Ix::try_from(index) {
+                Err(_) => fail!("Index must be non-negative"),
+                Ok(index) => Self::Index(index),
+            },
             ndarray::SliceInfoElem::Slice { start, end, step } => {
-                Self::Slice { start, step, end, block: false }
+                let start =
+                    Ix::try_from(start).map_err(|_| Error::from("Index must be non-negative"))?;
+                let step =
+                    Ix::try_from(step).map_err(|_| Error::from("Step must be non-negative"))?;
+                let end = end.map(|end| {
+                    Ix::try_from(end).map_err(|_| Error::from("End must be non-negative"))
+                });
+                match end {
+                    Some(Ok(end)) => Self::SliceTo { start, step, end, block: 1 },
+                    None => Self::Unlimited { start, step, block: 1 },
+                    Some(Err(e)) => return Err(e),
+                }
             }
-            ndarray::SliceInfoElem::NewAxis => panic!("ndarray NewAxis can not be mapped to hdf5"),
+            ndarray::SliceInfoElem::NewAxis => fail!("ndarray NewAxis can not be mapped to hdf5"),
+        })
+    }
+}
+
+impl TryFrom<ndarray::SliceInfoElem> for Hyperslab {
+    type Error = Error;
+    fn try_from(slice: ndarray::SliceInfoElem) -> Result<Self, Self::Error> {
+        Ok(vec![slice.try_into()?].into())
+    }
+}
+
+impl TryFrom<ndarray::SliceInfoElem> for Selection {
+    type Error = Error;
+    fn try_from(slice: ndarray::SliceInfoElem) -> Result<Self, Self::Error> {
+        Hyperslab::try_from(slice).map(Into::into)
+    }
+}
+
+impl From<RangeFull> for SliceOrIndex {
+    fn from(_r: RangeFull) -> Self {
+        Self::Unlimited { start: 0, step: 1, block: 1 }
+    }
+}
+
+impl TryFrom<ndarray::Slice> for SliceOrIndex {
+    type Error = std::num::TryFromIntError;
+    fn try_from(slice: ndarray::Slice) -> Result<Self, Self::Error> {
+        let ndarray::Slice { start, end, step } = slice;
+        let start = start.try_into()?;
+        let step = step.try_into()?;
+        let end = end.map(|end| end.try_into());
+        match end {
+            Some(Ok(end)) => Ok(Self::SliceTo { start, end, step, block: 1 }),
+            None => Ok(Self::Unlimited { start, step, block: 1 }),
+            Some(Err(e)) => Err(e),
         }
+    }
+}
+
+impl From<usize> for SliceOrIndex {
+    fn from(val: usize) -> Self {
+        Self::Index(val as _)
+    }
+}
+
+impl From<usize> for Hyperslab {
+    fn from(slice: usize) -> Self {
+        (slice,).into()
+    }
+}
+
+impl From<usize> for Selection {
+    fn from(slice: usize) -> Self {
+        Hyperslab::from(slice).into()
+    }
+}
+
+impl From<Range<usize>> for SliceOrIndex {
+    fn from(val: Range<usize>) -> Self {
+        Self::SliceTo { start: val.start as _, step: 1, end: val.end, block: 1 }
+    }
+}
+
+impl From<Range<usize>> for Hyperslab {
+    fn from(val: Range<usize>) -> Self {
+        vec![val.into()].into()
+    }
+}
+
+impl From<Range<usize>> for Selection {
+    fn from(val: Range<usize>) -> Self {
+        Hyperslab::from(val).into()
+    }
+}
+
+impl From<RangeToInclusive<usize>> for SliceOrIndex {
+    fn from(val: RangeToInclusive<usize>) -> Self {
+        let end = val.end + 1;
+        Self::SliceTo { start: 0, step: 1, end, block: 1 }
+    }
+}
+
+impl From<RangeToInclusive<usize>> for Hyperslab {
+    fn from(val: RangeToInclusive<usize>) -> Self {
+        vec![val.into()].into()
+    }
+}
+
+impl From<RangeToInclusive<usize>> for Selection {
+    fn from(val: RangeToInclusive<usize>) -> Self {
+        Hyperslab::from(val).into()
+    }
+}
+
+impl From<RangeFrom<usize>> for SliceOrIndex {
+    fn from(val: RangeFrom<usize>) -> Self {
+        Self::Unlimited { start: val.start, step: 1, block: 1 }
+    }
+}
+
+impl From<RangeFrom<usize>> for Hyperslab {
+    fn from(val: RangeFrom<usize>) -> Self {
+        vec![val.into()].into()
+    }
+}
+
+impl From<RangeFrom<usize>> for Selection {
+    fn from(val: RangeFrom<usize>) -> Self {
+        Hyperslab::from(val).into()
+    }
+}
+
+impl From<RangeInclusive<usize>> for SliceOrIndex {
+    fn from(val: RangeInclusive<usize>) -> Self {
+        Self::SliceTo { start: *val.start(), step: 1, end: *val.end() + 1, block: 1 }
+    }
+}
+
+impl From<RangeInclusive<usize>> for Hyperslab {
+    fn from(val: RangeInclusive<usize>) -> Self {
+        vec![val.into()].into()
+    }
+}
+
+impl From<RangeInclusive<usize>> for Selection {
+    fn from(val: RangeInclusive<usize>) -> Self {
+        Hyperslab::from(val).into()
+    }
+}
+
+impl From<RangeTo<usize>> for SliceOrIndex {
+    fn from(val: RangeTo<usize>) -> Self {
+        Self::SliceTo { start: 0, step: 1, end: val.end, block: 1 }
+    }
+}
+
+impl From<RangeTo<usize>> for Hyperslab {
+    fn from(val: RangeTo<usize>) -> Self {
+        vec![val.into()].into()
+    }
+}
+
+impl From<RangeTo<usize>> for Selection {
+    fn from(val: RangeTo<usize>) -> Self {
+        Hyperslab::from(val).into()
     }
 }
 
@@ -284,19 +530,29 @@ impl Display for SliceOrIndex {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Self::Index(index) => write!(f, "{}", index)?,
-            Self::Slice { start, end, step, block } => {
+            Self::SliceTo { start, end, step, block } => {
                 if start != 0 {
                     write!(f, "{}", start)?;
                 }
                 write!(f, "..")?;
-                if let Some(end) = end {
-                    write!(f, "{}", end)?;
-                }
+                write!(f, "{}", end)?;
                 if step != 1 {
                     write!(f, ";{}", step)?;
                 }
-                if block {
-                    write!(f, "(B)")?;
+                if block != 1 {
+                    write!(f, "(Bx{})", block)?;
+                }
+            }
+            Self::SliceCount { start, step, count, block } => {
+                if start != 0 {
+                    write!(f, "{}", start)?;
+                }
+                write!(f, "+{}", count)?;
+                if step != 1 {
+                    write!(f, ";{}", step)?;
+                }
+                if block != 1 {
+                    write!(f, "(Bx{})", block)?;
                 }
             }
             Self::Unlimited { start, step, block } => {
@@ -308,8 +564,8 @@ impl Display for SliceOrIndex {
                 if step != 1 {
                     write!(f, ";{}", step)?;
                 }
-                if block {
-                    write!(f, "(B)")?;
+                if block != 1 {
+                    write!(f, "(Bx{})", block)?;
                 }
             }
         }
@@ -318,6 +574,11 @@ impl Display for SliceOrIndex {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// A descriptor of a selection of an N-dimensional array.
+///
+/// The Hyperslab consists of [`slices`](SliceOrIndex) in N dimensions,
+/// spanning an N-dimensional hypercube. This type is used as a [`selector`](Selection)
+/// for retrieving and putting data to a [`Container`](Container).
 pub struct Hyperslab {
     dims: Vec<SliceOrIndex>,
 }
@@ -325,6 +586,10 @@ pub struct Hyperslab {
 impl Hyperslab {
     pub fn new<T: Into<Self>>(hyper: T) -> Self {
         hyper.into()
+    }
+
+    pub fn try_new<T: TryInto<Self>>(hyper: T) -> Result<Self, T::Error> {
+        hyper.try_into()
     }
 
     pub fn is_unlimited(&self) -> bool {
@@ -336,10 +601,7 @@ impl Hyperslab {
     }
 
     pub fn set_unlimited(&self, axis: usize) -> Result<Self> {
-        let unlim = self.unlimited_axis();
-        if unlim.is_some() && unlim != Some(axis) {
-            fail!("The hyperslab already has one unlimited axis");
-        } else if axis < self.len() {
+        if axis < self.len() {
             let mut hyper = self.clone();
             hyper.dims[axis] = hyper.dims[axis].to_unlimited()?;
             Ok(hyper)
@@ -348,14 +610,11 @@ impl Hyperslab {
         }
     }
 
-    pub fn set_block(&self, axis: usize) -> Result<Self> {
-        if axis < self.len() {
-            let mut hyper = self.clone();
-            hyper.dims[axis] = hyper.dims[axis].to_block()?;
-            Ok(hyper)
-        } else {
-            fail!("Invalid axis for changing the slice to block-like: {}", axis);
-        }
+    pub fn set_block(&self, axis: usize, blocksize: Ix) -> Result<Self> {
+        ensure!(axis < self.len(), "Invalid axis for changing the slice to block-like: {}", axis);
+        let mut hyper = self.clone();
+        hyper.dims[axis] = hyper.dims[axis].set_blocksize(blocksize)?;
+        Ok(hyper)
     }
 
     #[doc(hidden)]
@@ -363,8 +622,8 @@ impl Hyperslab {
         let shape = shape.as_ref();
         let ndim = shape.len();
         ensure!(self.len() == ndim, "Slice ndim ({}) != shape ndim ({})", self.len(), ndim);
-        let n_unlimited: usize = self.iter().map(|s| s.is_unlimited() as usize).sum();
-        ensure!(n_unlimited <= 1, "Expected at most 1 unlimited dimension, got {}", n_unlimited);
+        //let n_unlimited: usize = self.iter().map(|s| s.is_unlimited() as usize).sum();
+        //ensure!(n_unlimited <= 1, "Expected at most 1 unlimited dimension, got {}", n_unlimited);
         let hyper = RawHyperslab::from(
             self.iter()
                 .zip(shape)
@@ -379,29 +638,19 @@ impl Hyperslab {
     #[allow(clippy::needless_pass_by_value)]
     pub fn from_raw(hyper: RawHyperslab) -> Result<Self> {
         let mut dims = vec![];
-        for (i, slice) in hyper.iter().enumerate() {
-            let block = if slice.block == 1 {
-                false
-            } else if slice.block == slice.step {
-                true
-            } else {
-                fail!("Unsupported block/step for axis {}: {}/{}", i, slice.block, slice.step);
-            };
+        for (axis, slice) in hyper.iter().enumerate() {
+            ensure!(slice.step >= slice.block, "Blocks can not overlap (axis: {})", axis);
             dims.push(match slice.count {
-                Some(count) => SliceOrIndex::Slice {
-                    start: slice.start as _,
-                    step: slice.step as _,
-                    end: Some(
-                        (slice.start
-                            + if count == 0 { 0 } else { (count - 1) * slice.step + slice.block })
-                            as _,
-                    ),
-                    block,
+                Some(count) => SliceOrIndex::SliceCount {
+                    start: slice.start,
+                    step: slice.step,
+                    count,
+                    block: slice.block,
                 },
                 None => SliceOrIndex::Unlimited {
-                    start: slice.start as _,
-                    step: slice.step as _,
-                    block,
+                    start: slice.start,
+                    step: slice.step,
+                    block: slice.block,
                 },
             });
         }
@@ -441,45 +690,65 @@ impl From<SliceOrIndex> for Hyperslab {
     }
 }
 
-impl<T, Din, Dout> From<ndarray::SliceInfo<T, Din, Dout>> for Hyperslab
+impl TryFrom<ndarray::Slice> for Hyperslab {
+    type Error = Error;
+    fn try_from(slice: ndarray::Slice) -> Result<Self, Self::Error> {
+        Ok(vec![SliceOrIndex::try_from(slice).map_err(|_| Error::from("Invalid slice"))?].into())
+    }
+}
+
+impl<T, Din, Dout> TryFrom<ndarray::SliceInfo<T, Din, Dout>> for Hyperslab
 where
     T: AsRef<[ndarray::SliceInfoElem]>,
     Din: ndarray::Dimension,
     Dout: ndarray::Dimension,
 {
-    fn from(slice: ndarray::SliceInfo<T, Din, Dout>) -> Self {
-        slice.deref().as_ref().iter().copied().map(Into::into).collect::<Vec<_>>().into()
+    type Error = Error;
+    fn try_from(slice: ndarray::SliceInfo<T, Din, Dout>) -> Result<Self, Self::Error> {
+        slice
+            .deref()
+            .as_ref()
+            .iter()
+            .copied()
+            .map(TryInto::try_into)
+            .collect::<Result<Vec<_>>>()
+            .map(Into::into)
     }
 }
 
+/// Turns `SliceOrIndex` into real dimensions given `dim` as the maximum dimension
 fn slice_info_to_raw(axis: usize, slice: &SliceOrIndex, dim: Ix) -> Result<RawSlice> {
     let err_msg = || format!("out of bounds for axis {} with size {}", axis, dim);
     let (start, step, count, block) = match *slice {
         SliceOrIndex::Index(index) => {
-            let idx = abs_index(dim, index);
-            ensure!(idx >= 0 && idx < dim as _, "Index {} {}", index, err_msg());
-            (idx as _, 1, Some(1), 1)
+            ensure!(index < dim, "Index {} {}", index, err_msg());
+            (index, 1, 1, 1)
         }
-        SliceOrIndex::Slice { start, step, end, block } => {
+        SliceOrIndex::SliceTo { start, step, end, block } => {
             ensure!(step >= 1, "Slice stride {} < 1 for axis {}", step, axis);
-            let s = abs_index(dim, start);
-            ensure!(s >= 0 && s <= dim as _, "Slice start {} {}", start, err_msg());
-            let end = end.unwrap_or(dim as _);
-            let e = abs_index(dim, end);
-            ensure!(e >= 0 && e <= dim as _, "Slice end {} {}", end, err_msg());
-            let block = if block { step } else { 1 };
-            let count = if e < s + block { 0 } else { 1 + (e - s - block) / step };
-            (s as _, step as _, Some(count as _), block as _)
+            ensure!(start <= dim, "Slice start {} {}", start, err_msg());
+            ensure!(end <= dim, "Slice end {} {}", end, err_msg());
+            ensure!(step > 0, "Stride {} {}", step, err_msg());
+            let count = slice.count().unwrap();
+            (start, step, count, block)
+        }
+        SliceOrIndex::SliceCount { start, step, count, block } => {
+            ensure!(step >= 1, "Slice stride {} < 1 for axis {}", step, axis);
+            ensure!(start <= dim as _, "Slice start {} {}", start, err_msg());
+            let end = start + block.saturating_sub(1) + step * count.saturating_sub(1);
+            ensure!(end <= dim, "Slice end {} {}", end, err_msg());
+            (start, step, count, block)
         }
         SliceOrIndex::Unlimited { start, step, block } => {
-            ensure!(step >= 1, "Slice stride {} < 1 for axis {}", step, axis);
-            let s = abs_index(dim, start);
-            ensure!(s >= 0 && s <= dim as _, "Slice start {} {}", start, err_msg());
-            let block = if block { step } else { 1 };
-            (s as _, step as _, None, block as _)
+            // Replace infinite slice with one limited by the current dimension
+            return slice_info_to_raw(
+                axis,
+                &SliceOrIndex::SliceTo { start, step, end: dim, block },
+                dim,
+            );
         }
     };
-    Ok(RawSlice { start, step, count, block })
+    Ok(RawSlice { start, step, count: Some(count), block })
 }
 
 impl Display for Hyperslab {
@@ -500,6 +769,7 @@ impl Display for Hyperslab {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// A selection used for reading and writing to a [`Container`](Container).
 pub enum Selection {
     All,
     Points(Array2<Ix>),
@@ -515,6 +785,10 @@ impl Default for Selection {
 impl Selection {
     pub fn new<T: Into<Self>>(selection: T) -> Self {
         selection.into()
+    }
+
+    pub fn try_new<T: TryInto<Self>>(selection: T) -> Result<Self, T::Error> {
+        selection.try_into()
     }
 
     #[doc(hidden)]
@@ -669,14 +943,22 @@ impl From<Hyperslab> for Selection {
     }
 }
 
-impl<T, Din, Dout> From<ndarray::SliceInfo<T, Din, Dout>> for Selection
+impl TryFrom<ndarray::Slice> for Selection {
+    type Error = Error;
+    fn try_from(slice: ndarray::Slice) -> Result<Self, Self::Error> {
+        Hyperslab::try_from(slice).map(|x| x.into())
+    }
+}
+
+impl<T, Din, Dout> TryFrom<ndarray::SliceInfo<T, Din, Dout>> for Selection
 where
     T: AsRef<[ndarray::SliceInfoElem]>,
     Din: ndarray::Dimension,
     Dout: ndarray::Dimension,
 {
-    fn from(slice: ndarray::SliceInfo<T, Din, Dout>) -> Self {
-        Hyperslab::from(slice).into()
+    type Error = Error;
+    fn try_from(slice: ndarray::SliceInfo<T, Din, Dout>) -> Result<Self, Self::Error> {
+        Hyperslab::try_from(slice).map(Into::into)
     }
 }
 
@@ -686,14 +968,13 @@ impl From<Array2<Ix>> for Selection {
     }
 }
 
-#[allow(clippy::fallible_impl_from)]
 impl From<Array1<Ix>> for Selection {
     fn from(points: Array1<Ix>) -> Self {
         let n = points.len();
         Self::Points(if n == 0 {
             Array2::zeros((0, 0))
         } else {
-            points.into_shape((n, 1)).unwrap().into_dimensionality().unwrap()
+            points.insert_axis(ndarray::Axis(1))
         })
     }
 }
@@ -734,27 +1015,17 @@ impl From<&[Ix]> for Selection {
     }
 }
 
-macro_rules! impl_fixed {
-    () => ();
-
-    ($head:expr, $($tail:expr,)*) => (
-        impl From<[Ix; $head]> for Selection {
-            fn from(points: [Ix; $head]) -> Self {
-                points.as_ref().into()
-            }
-        }
-
-        impl From<&[Ix; $head]> for Selection {
-            fn from(points: &[Ix; $head]) -> Self {
-                points.as_ref().into()
-            }
-        }
-
-        impl_fixed! { $($tail,)* }
-    )
+impl<const N: usize> From<[Ix; N]> for Selection {
+    fn from(points: [Ix; N]) -> Self {
+        points.as_ref().into()
+    }
 }
 
-impl_fixed! { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, }
+impl<const N: usize> From<&[Ix; N]> for Selection {
+    fn from(points: &[Ix; N]) -> Self {
+        points.as_ref().into()
+    }
+}
 
 macro_rules! impl_tuple {
     () => ();
@@ -785,42 +1056,6 @@ macro_rules! impl_tuple {
 
 impl_tuple! { T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, }
 
-macro_rules! impl_slice_scalar {
-    ($tp:ty) => {
-        impl From<$tp> for Hyperslab {
-            fn from(slice: $tp) -> Self {
-                (slice,).into()
-            }
-        }
-
-        impl From<$tp> for Selection {
-            fn from(slice: $tp) -> Self {
-                Hyperslab::from(slice).into()
-            }
-        }
-    };
-}
-
-impl_slice_scalar!(isize);
-impl_slice_scalar!(usize);
-impl_slice_scalar!(i32);
-impl_slice_scalar!(ndarray::Slice);
-impl_slice_scalar!(ndarray::SliceInfoElem);
-
-macro_rules! impl_range_scalar {
-    ($index:ty) => {
-        impl_slice_scalar!(Range<$index>);
-        impl_slice_scalar!(RangeFrom<$index>);
-        impl_slice_scalar!(RangeInclusive<$index>);
-        impl_slice_scalar!(RangeTo<$index>);
-        impl_slice_scalar!(RangeToInclusive<$index>);
-    };
-}
-
-impl_range_scalar!(isize);
-impl_range_scalar!(usize);
-impl_range_scalar!(i32);
-
 #[cfg(test)]
 mod test {
     use ndarray::{arr1, arr2, s, Array2};
@@ -832,51 +1067,62 @@ mod test {
     use crate::internal_prelude::*;
 
     #[test]
+    fn count() {
+        use SliceOrIndex::*;
+        assert_eq!(Unlimited { start: 0, step: 1, block: 1 }.count(), None);
+        assert_eq!(Index(23412).count(), Some(1));
+        assert_eq!(SliceCount { start: 0, step: 1431, count: 41, block: 4 }.count(), Some(41));
+        assert_eq!(SliceTo { start: 0, step: 1, end: 1, block: 1 }.count(), Some(1));
+        assert_eq!(SliceTo { start: 0, step: 10, end: 1, block: 1 }.count(), Some(1));
+        assert_eq!(SliceTo { start: 0, step: 1, end: 10, block: 1 }.count(), Some(10));
+        assert_eq!(SliceTo { start: 0, step: 10, end: 10, block: 1 }.count(), Some(1));
+        assert_eq!(SliceTo { start: 0, step: 9, end: 10, block: 1 }.count(), Some(2));
+        assert_eq!(SliceTo { start: 0, step: 9, end: 10, block: 2 }.count(), Some(1));
+        assert_eq!(SliceTo { start: 1, step: 3, end: 6, block: 1 }.count(), Some(2));
+    }
+
+    #[test]
     fn test_slice_or_index_impl() -> Result<()> {
+        use std::convert::TryFrom;
         let s = SliceOrIndex::from(2);
         assert_eq!(s, Index(2));
         assert!(s.is_index());
         assert!(!s.is_slice());
         assert!(!s.is_unlimited());
         assert_err!(s.to_unlimited(), "Cannot make index selection unlimited");
-        assert_err!(s.to_block(), "Cannot make index selection block-like");
+        assert_err!(s.set_blocksize(2), "Cannot set blocksize for index selection");
 
         let s = SliceOrIndex::from(2..=5);
-        assert_eq!(s, Slice { start: 2, step: 1, end: Some(6), block: false });
+        assert_eq!(s, SliceTo { start: 2, step: 1, end: 6, block: 1 });
         assert!(!s.is_index());
         assert!(s.is_slice());
         assert!(!s.is_unlimited());
-        assert_err!(s.to_unlimited(), "Cannot make bounded slice unlimited");
-        assert_eq!(s.to_block()?, Slice { start: 2, step: 1, end: Some(6), block: true });
+        assert_eq!(s.to_unlimited().unwrap(), Unlimited { start: 2, step: 1, block: 1 });
+        assert_eq!(s.set_blocksize(4)?, SliceTo { start: 2, step: 1, end: 6, block: 4 });
         assert_eq!(
-            SliceOrIndex::from(*s![1..2;3].get(0).unwrap()),
-            Slice { start: 1, step: 3, end: Some(2), block: false }
+            SliceOrIndex::try_from(*s![1..2;3].get(0).unwrap()).unwrap(),
+            SliceTo { start: 1, step: 3, end: 2, block: 1 }
         );
 
         let s = SliceOrIndex::from(3..).to_unlimited()?;
-        assert_eq!(s, Unlimited { start: 3, step: 1, block: false });
+        assert_eq!(s, Unlimited { start: 3, step: 1, block: 1 });
         assert!(!s.is_index());
-        assert!(!s.is_slice());
+        assert!(s.is_slice());
         assert!(s.is_unlimited());
         assert_eq!(s.to_unlimited()?, s);
-        assert_eq!(s.to_block()?, Unlimited { start: 3, step: 1, block: true });
 
         for (s, f) in &[
-            (Index(-1), "-1"),
-            (Slice { start: 0, step: 1, end: None, block: false }, ".."),
-            (Slice { start: 0, step: 1, end: None, block: true }, "..(B)"),
-            (Slice { start: -1, step: 3, end: None, block: false }, "-1..;3"),
-            (Slice { start: -1, step: 1, end: None, block: true }, "-1..(B)"),
-            (Slice { start: 0, step: 1, end: Some(5), block: false }, "..5"),
-            (Slice { start: 0, step: 3, end: Some(5), block: true }, "..5;3(B)"),
-            (Slice { start: -1, step: 1, end: Some(5), block: false }, "-1..5"),
-            (Slice { start: -1, step: 1, end: Some(5), block: true }, "-1..5(B)"),
-            (Unlimited { start: 0, step: 1, block: false }, "..∞"),
-            (Unlimited { start: 0, step: 3, block: true }, "..∞;3(B)"),
-            (Unlimited { start: -1, step: 1, block: false }, "-1..∞"),
-            (Unlimited { start: -1, step: 3, block: true }, "-1..∞;3(B)"),
+            (Unlimited { start: 0, step: 1, block: 1 }, "..∞"),
+            (Unlimited { start: 0, step: 1, block: 2 }, "..∞(Bx2)"),
+            (SliceTo { start: 0, step: 1, end: 5, block: 1 }, "..5"),
+            (SliceTo { start: 0, step: 3, end: 5, block: 2 }, "..5;3(Bx2)"),
+            (Unlimited { start: 0, step: 1, block: 1 }, "..∞"),
+            (Unlimited { start: 0, step: 3, block: 2 }, "..∞;3(Bx2)"),
+            (SliceCount { start: 1, step: 3, count: 5, block: 1 }, "1+5;3"),
+            (SliceCount { start: 0, step: 3, count: 5, block: 2 }, "+5;3(Bx2)"),
+            (SliceCount { start: 1, step: 3, count: 5, block: 2 }, "1+5;3(Bx2)"),
         ] {
-            assert_eq!(format!("{}", s), f.to_owned());
+            assert_eq!(&format!("{}", s), f);
         }
 
         Ok(())
@@ -886,8 +1132,8 @@ mod test {
     fn test_selection_hyperslab_new() {
         macro_rules! check {
             ($hs1:expr, $hs2:expr) => {
-                assert_eq!(Hyperslab::new($hs1).as_ref().to_owned(), $hs2);
-                let s = Selection::new($hs1);
+                assert_eq!(Hyperslab::try_new($hs1).unwrap().as_ref().to_owned(), $hs2);
+                let s = Selection::try_new($hs1).unwrap();
                 assert_eq!(s, Selection::new(Hyperslab::new($hs2)));
                 assert_eq!(s, Selection::Hyperslab(Hyperslab::new($hs2)));
             };
@@ -895,38 +1141,18 @@ mod test {
 
         check!((), vec![]);
         check!(Index(2), vec![Index(2)]);
-        check!(
-            s![-1, 2..;3, ..4],
-            vec![
-                Index(-1),
-                Slice { start: 2, step: 3, end: None, block: false },
-                Slice { start: 0, step: 1, end: Some(4), block: false },
-            ]
-        );
-
-        check!(
-            ndarray::Slice::new(-1, None, 2),
-            vec![Slice { start: -1, step: 2, end: None, block: false }]
-        );
         check!(ndarray::SliceInfoElem::Index(10), vec![Index(10)]);
-
-        check!(-1, vec![Index(-1)]);
-        check!(-1..2, vec![Slice { start: -1, step: 1, end: Some(2), block: false }]);
-        check!(-1..=2, vec![Slice { start: -1, step: 1, end: Some(3), block: false }]);
-        check!(3.., vec![Slice { start: 3, step: 1, end: None, block: false }]);
-        check!(..-1, vec![Slice { start: 0, step: 1, end: Some(-1), block: false }]);
-        check!(..=-1, vec![Slice { start: 0, step: 1, end: None, block: false }]);
-
-        check!(
-            (-1..2, Index(-1)),
-            vec![Slice { start: -1, step: 1, end: Some(2), block: false }, Index(-1)]
-        );
+        check!(3.., vec![Unlimited { start: 3, step: 1, block: 1 }]);
 
         assert_eq!(
             Hyperslab::new(..).as_ref().to_owned(),
-            vec![Slice { start: 0, step: 1, end: None, block: false }]
+            vec![Unlimited { start: 0, step: 1, block: 1 }]
         );
         assert_eq!(Selection::new(..), Selection::All);
+
+        use std::convert::TryFrom;
+        assert!(Selection::try_from(s![-1, 2..;3, ..4]).is_err());
+        assert!(Selection::try_from(ndarray::Slice::new(-1, None, 2)).is_err());
     }
 
     #[test]
@@ -958,20 +1184,20 @@ mod test {
 
     #[test]
     fn test_hyperslab_impl() -> Result<()> {
-        let h = Hyperslab::new(s![0, 1..10, 2..;3]);
+        let h = Hyperslab::try_new(s![0, 1..10, 2..;3])?;
         assert_eq!(
             h.as_ref().to_owned(),
             vec![
                 Index(0),
-                Slice { start: 1, step: 1, end: Some(10), block: false },
-                Slice { start: 2, step: 3, end: None, block: false },
+                SliceTo { start: 1, step: 1, end: 10, block: 1 },
+                Unlimited { start: 2, step: 3, block: 1 },
             ]
         );
-        assert!(!h.is_unlimited());
-        assert!(h.unlimited_axis().is_none());
+        assert!(h.is_unlimited());
+        assert_eq!(h.unlimited_axis(), Some(2));
 
         assert_err!(h.set_unlimited(0), "Cannot make index selection unlimited");
-        assert_err!(h.set_unlimited(1), "Cannot make bounded slice unlimited");
+        h.set_unlimited(1)?;
         assert_err!(h.set_unlimited(3), "Invalid axis for making hyperslab unlimited: 3");
         let u = h.set_unlimited(2)?;
         assert!(u.is_unlimited());
@@ -980,34 +1206,34 @@ mod test {
             u.as_ref().to_owned(),
             vec![
                 Index(0),
-                Slice { start: 1, step: 1, end: Some(10), block: false },
-                Unlimited { start: 2, step: 3, block: false },
+                SliceTo { start: 1, step: 1, end: 10, block: 1 },
+                Unlimited { start: 2, step: 3, block: 1 },
             ]
         );
-        assert_err!(u.set_unlimited(1), "The hyperslab already has one unlimited axis");
+        u.set_unlimited(1).unwrap();
         assert_eq!(u.set_unlimited(2)?, u);
 
-        assert_err!(u.set_block(0), "Cannot make index selection block-like");
-        assert_err!(u.set_block(3), "Invalid axis for changing the slice to block-like: 3");
-        let b = u.set_block(1)?;
+        assert_err!(u.set_block(0, 1), "Cannot set blocksize for index selection");
+        assert_err!(u.set_block(3, 1), "Invalid axis for changing the slice to block-like: 3");
+        let b = u.set_block(1, 2)?;
         assert_eq!(
             b.as_ref().to_owned(),
             vec![
                 Index(0),
-                Slice { start: 1, step: 1, end: Some(10), block: true },
-                Unlimited { start: 2, step: 3, block: false },
+                SliceTo { start: 1, step: 1, end: 10, block: 2 },
+                Unlimited { start: 2, step: 3, block: 1 },
             ]
         );
-        let b = b.set_block(2)?;
+        let b = b.set_block(2, 2)?;
         assert_eq!(
             b.as_ref().to_owned(),
             vec![
                 Index(0),
-                Slice { start: 1, step: 1, end: Some(10), block: true },
-                Unlimited { start: 2, step: 3, block: true },
+                SliceTo { start: 1, step: 1, end: 10, block: 2 },
+                Unlimited { start: 2, step: 3, block: 2 },
             ]
         );
-        assert_eq!(b.set_block(1)?.set_block(2)?, b);
+        assert_eq!(b.set_block(1, 2)?.set_block(2, 2)?, b);
 
         Ok(())
     }
@@ -1055,7 +1281,7 @@ mod test {
 
     #[test]
     fn test_selection_hyperslab_impl() {
-        let s = Selection::new(s![1, 2..;2]);
+        let s = Selection::try_new(s![1, 2..;2]).unwrap();
         assert_eq!(s, s);
         assert!(!s.is_all() && s.is_hyperslab() && !s.is_points() && !s.is_none());
         assert_ne!(s, Selection::new(..));
@@ -1063,64 +1289,49 @@ mod test {
         assert_eq!(s.in_ndim(), Some(2));
         assert_eq!(s.out_ndim(), Some(1));
         assert_eq!(s.out_shape(&[10, 20]).unwrap(), &[9]);
-        assert_eq!(format!("{}", Selection::new(s![1])), "(1,)");
+        assert_eq!(format!("{}", Selection::try_new(s![1]).unwrap()), "(1,)");
         assert_eq!(format!("{}", Selection::new(())), "()");
 
-        let h = Hyperslab::new(s![1, 2..;3, ..4, 5..]).set_unlimited(1).unwrap();
-        assert_eq!(format!("{}", h), "(1, 2..∞;3, ..4, 5..)");
+        let h = Hyperslab::try_new(s![1, 2..;3, ..4, 5..]).unwrap().set_unlimited(1).unwrap();
+        assert_eq!(format!("{}", h), "(1, 2..∞;3, ..4, 5..∞)");
         let s = Selection::new(h);
-        assert_eq!(format!("{}", s), "(1, 2..∞;3, ..4, 5..)");
-        assert_err!(s.out_shape(&[2, 3, 4, 5]), "Unable to get the shape for unlimited hyperslab");
+        assert_eq!(format!("{}", s), "(1, 2..∞;3, ..4, 5..∞)");
+        assert_eq!(s.out_shape(&[2, 3, 4, 5]).unwrap(), &[1, 4, 0]);
     }
 
     #[test]
     fn test_hyperslab_into_from_raw_err() {
-        fn check<H: Into<Hyperslab>, S: AsRef<[Ix]>>(hyper: H, shape: S, err: &str) {
-            assert_err!(hyper.into().into_raw(shape.as_ref()), err);
+        use std::convert::TryInto;
+        #[track_caller]
+        fn check<H: TryInto<Hyperslab>, S: AsRef<[Ix]>>(hyper: H, shape: S, err: &str)
+        where
+            H::Error: std::fmt::Debug,
+        {
+            let hyper = hyper.try_into().unwrap();
+            assert_err!(hyper.into_raw(shape.as_ref()), err);
         }
 
-        check(
-            Hyperslab::new(vec![
-                Unlimited { start: 0, step: 1, block: false },
-                Unlimited { start: 0, step: 1, block: false },
-            ]),
-            &[1, 2],
-            "Expected at most 1 unlimited dimension, got 2",
-        );
-
         check(s![1, 2], &[1, 2, 3], "Slice ndim (2) != shape ndim (3)");
-
-        check(s![0, ..;-1], &[1, 2], "Slice stride -1 < 1 for axis 1");
-
+        assert!(Hyperslab::try_new(s![0, ..;-1]).is_err());
         check(s![0, 0], &[0, 1], "Index 0 out of bounds for axis 0 with size 0");
         check(s![.., 1], &[0, 1], "Index 1 out of bounds for axis 1 with size 1");
-        check(s![-3], &[2], "Index -3 out of bounds for axis 0 with size 2");
+        assert!(Hyperslab::try_new(s![-3]).is_err());
         check(s![2], &[2], "Index 2 out of bounds for axis 0 with size 2");
 
         check(s![0, 3..], &[1, 2], "Slice start 3 out of bounds for axis 1 with size 2");
-        check(s![-2..;2, 0], &[1, 2], "Slice start -2 out of bounds for axis 0 with size 1");
+        assert!(Hyperslab::try_new(s![-2..;2, 0]).is_err());
         check(s![0, ..=3], &[1, 2], "Slice end 4 out of bounds for axis 1 with size 2");
-        check(s![..-3;2, 0], &[1, 2], "Slice end -3 out of bounds for axis 0 with size 1");
+        assert!(Hyperslab::try_new(s![-2..;2, 0]).is_err());
 
         check(
-            (0, Unlimited { start: 0, step: -1, block: true }),
-            &[1, 2],
-            "Slice stride -1 < 1 for axis 1",
-        );
-        check(
-            (0, Unlimited { start: 3, step: 1, block: false }),
+            (0, Unlimited { start: 3, step: 1, block: 1 }),
             &[1, 2],
             "Slice start 3 out of bounds for axis 1 with size 2",
-        );
-        check(
-            (Unlimited { start: -2, step: 2, block: true }, 0),
-            &[1, 2],
-            "Slice start -2 out of bounds for axis 0 with size 1",
         );
 
         assert_err!(
             Hyperslab::from_raw(vec![RawSlice::new(0, 2, Some(1), 3)].into()),
-            "Unsupported block/step for axis 0: 3/2"
+            "Blocks can not overlap (axis: 0)"
         );
     }
 
@@ -1134,48 +1345,51 @@ mod test {
 
     #[test]
     fn test_hyperslab_into_from_raw() -> Result<()> {
+        use std::convert::TryInto;
         fn check<S, H, RH, RS, H2, S2>(
             shape: S, hyper: H, exp_raw_hyper: RH, exp_raw_sel: Option<RS>, exp_hyper2: H2,
             exp_sel2: Option<S2>,
-        ) -> Result<()>
-        where
+        ) where
             S: AsRef<[Ix]>,
-            H: Into<Hyperslab>,
+            H: TryInto<Hyperslab>,
+            H::Error: std::fmt::Debug,
             RH: Into<RawHyperslab>,
             RS: Into<RawSelection>,
-            H2: Into<Hyperslab>,
-            S2: Into<Selection>,
+            H2: TryInto<Hyperslab>,
+            H2::Error: std::fmt::Debug,
+            S2: TryInto<Selection>,
+            S2::Error: std::fmt::Debug,
         {
             let shape = shape.as_ref();
-            let hyper = hyper.into();
+            let hyper = hyper.try_into().unwrap();
             let exp_raw_hyper = exp_raw_hyper.into();
             let exp_raw_sel = exp_raw_sel.map(Into::into).unwrap_or(exp_raw_hyper.clone().into());
-            let exp_hyper2 = exp_hyper2.into();
-            let exp_sel2 = exp_sel2.map(Into::into).unwrap_or(exp_hyper2.clone().into());
+            let exp_hyper2 = exp_hyper2.try_into().unwrap();
+            let exp_sel2 = exp_sel2
+                .map(|x| TryInto::try_into(x).unwrap())
+                .unwrap_or(exp_hyper2.clone().try_into().unwrap());
 
-            let raw_hyper = hyper.clone().into_raw(shape)?;
+            let raw_hyper = hyper.clone().into_raw(shape).unwrap();
             assert_eq!(raw_hyper, exp_raw_hyper);
 
             let sel = Selection::new(hyper.clone());
-            let raw_sel = sel.clone().into_raw(shape)?;
+            let raw_sel = sel.clone().into_raw(shape).unwrap();
             assert_eq!(raw_sel, exp_raw_sel);
 
-            let hyper2 = Hyperslab::from_raw(raw_hyper.clone())?;
+            let hyper2 = Hyperslab::from_raw(raw_hyper.clone()).unwrap();
             assert_eq!(hyper2, exp_hyper2);
 
-            let sel2 = Selection::from_raw(raw_sel.clone())?;
+            let sel2 = Selection::from_raw(raw_sel.clone()).unwrap();
             assert_eq!(sel2, exp_sel2);
 
-            let raw_hyper2 = hyper2.clone().into_raw(shape)?;
+            let raw_hyper2 = hyper2.clone().into_raw(shape).unwrap();
             assert_eq!(raw_hyper2, raw_hyper);
 
-            let raw_sel2 = sel2.clone().into_raw(shape)?;
+            let raw_sel2 = sel2.clone().into_raw(shape).unwrap();
             assert_eq!(raw_sel2, raw_sel);
-
-            Ok(())
         }
 
-        check(&[], (), vec![], Some(RawSelection::All), (), Some(Selection::All))?;
+        check(&[], (), vec![], Some(RawSelection::All), (), Some(Selection::All));
 
         check(
             &[5, 5, 5],
@@ -1184,7 +1398,7 @@ mod test {
             Some(RawSelection::All),
             s![..5, ..5, ..5],
             Some(Selection::All),
-        )?;
+        );
 
         check(
             &[0; 6],
@@ -1200,61 +1414,22 @@ mod test {
             Some(RawSelection::None),
             s![..0, ..0, ..0, ..0, ..0, ..0;2],
             Some(Selection::new(&[])),
-        )?;
+        );
 
-        check(
-            &[3; 10],
-            s![.., ..;2, 1.., 1..;2, -3..=1, -3..=-1;2, ..=-1, ..=-1;3, 0..-1, 2..=-1],
-            vec![
-                RawSlice::new(0, 1, Some(3), 1),
-                RawSlice::new(0, 2, Some(2), 1),
-                RawSlice::new(1, 1, Some(2), 1),
-                RawSlice::new(1, 2, Some(1), 1),
-                RawSlice::new(0, 1, Some(2), 1),
-                RawSlice::new(0, 2, Some(2), 1),
-                RawSlice::new(0, 1, Some(3), 1),
-                RawSlice::new(0, 3, Some(1), 1),
-                RawSlice::new(0, 1, Some(2), 1),
-                RawSlice::new(2, 1, Some(1), 1),
-            ],
-            None as Option<RawSelection>,
-            s![..3, ..3;2, 1..3, 1..2;2, ..=1, ..3;2, ..3, ..1;3, 0..2, 2..3],
-            None as Option<Selection>,
-        )?;
-
-        check(
-            &[10; 4],
-            s![-5.., -10, 1..-1;2, 1],
-            vec![
-                RawSlice::new(5, 1, Some(5), 1),
-                RawSlice::new(0, 1, Some(1), 1),
-                RawSlice::new(1, 2, Some(4), 1),
-                RawSlice::new(1, 1, Some(1), 1),
-            ],
-            None as Option<RawSelection>,
-            s![5..10, 0..1, 1..8;2, 1..2],
-            None as Option<Selection>,
-        )?;
-
-        check(
-            &[10; 3],
-            Hyperslab::new(s![-5..;2, -10, 1..-3;3])
-                .set_unlimited(0)?
-                .set_block(0)?
-                .set_block(2)?,
-            vec![
-                RawSlice::new(5, 2, None, 2),
-                RawSlice::new(0, 1, Some(1), 1),
-                RawSlice::new(1, 3, Some(2), 3),
-            ],
-            None as Option<RawSelection>,
-            Hyperslab::new(s![5..;2, 0..1, 1..7;3]).set_unlimited(0)?.set_block(0)?.set_block(2)?,
-            None as Option<Selection>,
-        )?;
+        assert!(Hyperslab::try_new(
+            s![.., ..;2, 1.., 1..;2, -3..=1, -3..=-1;2, ..=-1, ..=-1;3, 0..-1, 2..=-1]
+        )
+        .is_err());
+        assert!(Hyperslab::try_new(
+            s![.., ..;2, 1.., 1..;2, -3..=1, -3..=-1;2, ..=-1, ..=-1;3, 0..-1, 2..=-1]
+        )
+        .is_err());
+        assert!(Hyperslab::try_new(s![-5.., -10, 1..-1;2, 1],).is_err());
+        assert!(Hyperslab::try_new(s![5..10, 0..1, 1..8;2, 1..2],).is_ok());
 
         check(
             &[7; 7],
-            Hyperslab::new(s![1..2;3, 1..3;3, 1..4;3, 1..5;3, 1..6;3, 1..7;3, ..7;3]),
+            Hyperslab::try_new(s![1..2;3, 1..3;3, 1..4;3, 1..5;3, 1..6;3, 1..7;3, ..7;3])?,
             vec![
                 RawSlice::new(1, 3, Some(1), 1),
                 RawSlice::new(1, 3, Some(1), 1),
@@ -1265,42 +1440,24 @@ mod test {
                 RawSlice::new(0, 3, Some(3), 1),
             ],
             None as Option<RawSelection>,
-            Hyperslab::new(s![1..2;3, 1..2;3, 1..2;3, 1..5;3, 1..5;3, 1..5;3, ..7;3]),
+            Hyperslab::try_new(s![1..2;3, 1..2;3, 1..2;3, 1..5;3, 1..5;3, 1..5;3, ..7;3])?,
             None as Option<Selection>,
-        )?;
-
-        check(
-            &[7; 4],
-            Hyperslab::new(s![1..4;3, 1..5;3, 1..6;3, 1..7;3])
-                .set_block(0)?
-                .set_block(1)?
-                .set_block(2)?
-                .set_block(3)?,
-            vec![
-                RawSlice::new(1, 3, Some(1), 3),
-                RawSlice::new(1, 3, Some(1), 3),
-                RawSlice::new(1, 3, Some(1), 3),
-                RawSlice::new(1, 3, Some(2), 3),
-            ],
-            None as Option<RawSelection>,
-            Hyperslab::new(s![1..4;3, 1..4;3, 1..4;3, 1..7;3])
-                .set_block(0)?
-                .set_block(1)?
-                .set_block(2)?
-                .set_block(3)?,
-            None as Option<Selection>,
-        )?;
+        );
 
         Ok(())
     }
 
     #[test]
     fn test_in_out_shape_ndim() -> Result<()> {
-        fn check<S: Into<Selection>, E: AsRef<[Ix]>>(
+        use std::convert::TryInto;
+        fn check<S: TryInto<Selection>, E: AsRef<[Ix]>>(
             sel: S, exp_in_ndim: Option<usize>, exp_out_shape: E, exp_out_ndim: Option<usize>,
-        ) -> Result<()> {
+        ) -> Result<()>
+        where
+            S::Error: std::fmt::Debug,
+        {
             let in_shape = [7, 8];
-            let sel = sel.into();
+            let sel = sel.try_into().unwrap();
             assert_eq!(sel.in_ndim(), exp_in_ndim);
             let out_shape = sel.out_shape(&in_shape)?;
             let out_ndim = sel.out_ndim();
@@ -1322,10 +1479,10 @@ mod test {
         check(s![1, 2..;2], Some(2), [3], Some(1))?;
         check(s![1..;3, 2], Some(2), [2], Some(1))?;
         check(s![1..;3, 2..;2], Some(2), [2, 3], Some(2))?;
-        check(Hyperslab::new(s![1, 2..;2]).set_block(1)?, Some(2), [6], Some(1))?;
-        check(Hyperslab::new(s![1..;3, 2]).set_block(0)?, Some(2), [6], Some(1))?;
+        check(Hyperslab::try_new(s![1, 2..;2])?.set_block(1, 6)?, Some(2), [6], Some(1))?;
+        check(Hyperslab::try_new(s![1..;3, 2])?.set_block(0, 6)?, Some(2), [6], Some(1))?;
         check(
-            Hyperslab::new(s![1..;3, 2..;2]).set_block(0)?.set_block(1)?,
+            Hyperslab::try_new(s![1..;3, 2..;2])?.set_block(0, 6)?.set_block(1, 6)?,
             Some(2),
             [6, 6],
             Some(2),
@@ -1345,19 +1502,22 @@ mod test {
 
     #[test]
     fn test_selection_into_from_raw() -> Result<()> {
+        use std::convert::TryInto;
         fn check<Sh, S, RS, S2>(
             shape: Sh, sel: S, exp_raw_sel: RS, exp_sel2: Option<S2>,
         ) -> Result<()>
         where
             Sh: AsRef<[Ix]>,
-            S: Into<Selection>,
+            S: TryInto<Selection>,
+            S::Error: std::fmt::Debug,
             RS: Into<RawSelection>,
-            S2: Into<Selection>,
+            S2: TryInto<Selection>,
+            S2::Error: std::fmt::Debug,
         {
             let shape = shape.as_ref();
-            let sel = sel.into();
+            let sel = sel.try_into().unwrap();
             let exp_raw_sel = exp_raw_sel.into();
-            let exp_sel2 = exp_sel2.map_or(sel.clone(), Into::into);
+            let exp_sel2 = exp_sel2.map_or(sel.clone(), |x| x.try_into().unwrap());
 
             let raw_sel = sel.clone().into_raw(shape)?;
             assert_eq!(raw_sel, exp_raw_sel);
@@ -1381,7 +1541,6 @@ mod test {
             None as Option<Selection>,
         )?;
         check(&[5, 6], s![1..1;2, 3], RawSelection::None, Some(&[]))?;
-        check(&[5, 6], s![-5.., 0..], RawSelection::All, Some(..))?;
         check(
             &[5, 6],
             s![1..;2, 3],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::unnecessary_unwrap))]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::unnecessary_wraps))]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::upper_case_acronyms))]
+#![cfg_attr(feature = "cargo-clippy", allow(clippy::missing_panics_doc))]
 #![cfg_attr(all(feature = "cargo-clippy", test), allow(clippy::cyclomatic_complexity))]
 #![cfg_attr(not(test), allow(dead_code))]
 
@@ -37,7 +38,8 @@ mod export {
             Attribute, AttributeBuilder, AttributeBuilderData, AttributeBuilderEmpty,
             AttributeBuilderEmptyShape, Container, Conversion, Dataset, DatasetBuilder,
             DatasetBuilderData, DatasetBuilderEmpty, DatasetBuilderEmptyShape, Dataspace, Datatype,
-            File, FileBuilder, Group, Location, Object, PropertyList, Reader, Writer,
+            File, FileBuilder, Group, LinkInfo, LinkType, Location, LocationInfo, LocationToken,
+            LocationType, Object, PropertyList, Reader, Writer,
         },
     };
 

--- a/tests/test_plist.rs
+++ b/tests/test_plist.rs
@@ -785,8 +785,9 @@ fn test_dcpl_virtual_map() -> hdf5::Result<()> {
     let pl = DCB::new()
         .layout(Layout::Virtual)
         .virtual_map("foo", "bar", (3, 4..), (.., 1..), (10..=20, 10), (..3, 7..))
-        .virtual_map("x", "y", 100, 91.., 12, Hyperslab::new(s![2..;3]).set_block(0)?)
-        .finish()?;
+        .virtual_map("x", "y", 100, 96.., 12, Hyperslab::try_new(s![2..;3])?)
+        .finish()
+        .unwrap();
     let expected = vec![
         VirtualMapping {
             src_filename: "foo".into(),
@@ -800,9 +801,9 @@ fn test_dcpl_virtual_map() -> hdf5::Result<()> {
             src_filename: "x".into(),
             src_dataset: "y".into(),
             src_extents: 100.into(),
-            src_selection: (91..100).into(),
+            src_selection: (96..100).into(),
             vds_extents: 12.into(),
-            vds_selection: Hyperslab::new(s![2..11;3]).set_block(0)?.into(),
+            vds_selection: Hyperslab::try_new(s![2..12;3])?.into(),
         },
     ];
     assert_eq!(pl.get_virtual_map()?, expected);


### PR DESCRIPTION
This is a new way of handling object identifiers given by us from the `hdf5-c` library. 

The old approach was to store the handles in a registry, a hashmap that kept track of all previous identfiers. Each object addtionally kept track of whether it is invalid or not through an `RwLock`. This works very well for our tests, but fails when opening and closing many objects (#76, #137).

This PR instead relies on `hdf5-c` to keep track of the identifiers and validity. The `Handle` is now a type which owns the underlying object directly, and ownership is a bit stricter. 

In practical terms this does not change much. Opened file objects will not be automatically closed when a file is dropped, the user must set the strong close degree on the file to get this behaviour. Setting the strong close degree is dangerous (in the sense it closes the wrong items), but not unsafe, and a warning has been added to the corresponding function.

The idea is to strengthen the relationship between an object handle on the `rust` side and the `hdf5` side. A handle owns the object, and is cloned by incrementing the reference count and handing out a new object. The old approach was to try and close all related handles, acting as a half `FileCloseDegree::Strong`. The new approach requires the user to explicitely opt into this behaviour, with all the pitfalls this entails...

Soundness difficulties (but not memory safety concern) leading to double free:
* Creating a new borrowed object from an ID without incref
* `decref` without incref
* The strong file close degree

Should we remove or change some items from our API to remove some of these? We could add a counterpart of `from_id` (`from_borrowed_id`), make `decref` hidden, and use `unsafe` to annotate these functions.